### PR TITLE
Students only see their submitted psets and their incompleted psets

### DIFF
--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -17,13 +17,17 @@ class ClassroomsController < ApplicationController
     @classroom_psets = ClassroomPset
       .where(classroom: @classroom)
       .joins(:p_set)
-      .joins('LEFT JOIN p_set_answers ON p_set_answers.p_set_id = p_sets.id')
-      .select('p_set_answers.completed AS completed')
-			.select('p_set_answers.user_id AS user_id')
       .select('p_sets.id AS p_set_id, p_sets.name AS p_set_name')
       .select('classroom_psets.*')
       .order('created_at ASC')
       .to_a
+
+		@student_answers = ClassroomPset
+			.where(classroom: @classroom)
+			.joins(p_set: [:p_set_answers])
+			.where("p_set_answers.completed" => true)
+			.where("p_set_answers.user_id" => current_user.id)
+			.pluck(:name)
   end
 
   # index for finding a class to join

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -15,7 +15,7 @@
               <tr>
                   <td><%= crp.p_set_name %> </td>
                   <td>
-                      <%= (crp.completed.nil? || !crp.completed || (current_user.id != crp.user_id))?
+                      <%= (@student_answers.find_index(crp.p_set_name).nil? )?
                       link_to('Go to PSet', p_set_rhythm_path(crp.p_set_id)) :
                       'Yes' %>
                   </td>


### PR DESCRIPTION
Added an extra query to classrooms_controller as a cross reference.
First query gets all the classroom_psets associated with the current class
Second query gets all of the pset_answers for the classroom that belongs to the current user and is completed, then 'plucks' out the name attribute.